### PR TITLE
fix(cmd/gf): fix gf gen dao with removeFieldPrefix 

### DIFF
--- a/cmd/gf/internal/cmd/gendao/gendao_structure.go
+++ b/cmd/gf/internal/cmd/gendao/gendao_structure.go
@@ -71,7 +71,6 @@ func generateStructFieldDefinition(
 		err              error
 		localTypeName    gdb.LocalType
 		localTypeNameStr string
-		jsonTag          = gstr.CaseConvert(field.Name, gstr.CaseTypeMatch(in.JsonCase))
 	)
 
 	if in.TypeMapping != nil && len(in.TypeMapping) > 0 {
@@ -143,6 +142,8 @@ func generateStructFieldDefinition(
 		"    #" + formatFieldName(newFiledName, FieldNameCaseCamel),
 		" #" + localTypeNameStr,
 	}
+
+	jsonTag := gstr.CaseConvert(newFiledName, gstr.CaseTypeMatch(in.JsonCase))
 	attrLines = append(attrLines, fmt.Sprintf(` #%sjson:"%s"`, tagKey, jsonTag))
 	// orm tag
 	if !in.IsDo {


### PR DESCRIPTION
Fixed: #4113
when use "removeFieldPrefix" config to generate entity, also delete prefix in json tag